### PR TITLE
Update the test framework to support Solana 1.14 and anchor 0.26

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-test-framework"
-version = "1.14.11"
+version = "1.14"
 edition = "2021"
 authors = ["lowprivuser"]
 
@@ -10,12 +10,12 @@ authors = ["lowprivuser"]
 anchor = ["anchor-lang"]
 
 [dependencies]
-solana-program-test = "1.14.11"
-solana-sdk = "1.14.11"
-solana-program ="1.14.11"
-solana-banks-client = "1.14.11"
-solana-program-runtime = "1.14.11"
-solana-client = "1.14.11"
+solana-program-test = "1.14"
+solana-sdk = "1.14"
+solana-program ="1.14"
+solana-banks-client = "1.14"
+solana-program-runtime = "1.14"
+solana-client = "1.14"
 spl-token = "3.5.0"
 spl-associated-token-account = "1.1.2"
 anchor-lang = { version = "0.26.0", optional = true }
@@ -28,4 +28,4 @@ chrono-humanize = "0.2"
 
 [dev-dependencies]
 program-for-tests = {path="tests/artifacts/program_for_tests"}
-solana-test-validator = "1.14.11"
+solana-test-validator = "1.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-test-framework"
-version = "1.14.0"
+version = "1.14.11"
 edition = "2021"
 authors = ["lowprivuser"]
 
@@ -10,12 +10,12 @@ authors = ["lowprivuser"]
 anchor = ["anchor-lang"]
 
 [dependencies]
-solana-program-test = "1.14.0"
-solana-sdk = "1.14.0"
-solana-program ="1.14.0"
-solana-banks-client = "1.14.0"
-solana-program-runtime = "1.14.0"
-solana-client = "1.14.0"
+solana-program-test = "1.14.11"
+solana-sdk = "1.14.11"
+solana-program ="1.14.11"
+solana-banks-client = "1.14.11"
+solana-program-runtime = "1.14.11"
+solana-client = "1.14.11"
 spl-token = "3.5.0"
 spl-associated-token-account = "1.1.2"
 anchor-lang = { version = "0.26.0", optional = true }
@@ -28,4 +28,4 @@ chrono-humanize = "0.2"
 
 [dev-dependencies]
 program-for-tests = {path="tests/artifacts/program_for_tests"}
-solana-test-validator = "1.14.0"
+solana-test-validator = "1.14.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-test-framework"
-version = "1.1.0"
+version = "1.14.0"
 edition = "2021"
 authors = ["lowprivuser"]
 
@@ -10,15 +10,15 @@ authors = ["lowprivuser"]
 anchor = ["anchor-lang"]
 
 [dependencies]
-solana-program-test = "1.10"
-solana-sdk = "1.10"
-solana-program = "1.10"
-solana-banks-client = "1.10"
-solana-program-runtime = "1.10"
-solana-client = "1.10"
-spl-token = "3.3.0"
-spl-associated-token-account = "~1.0.5"
-anchor-lang = { version = "0.25.0", optional = true }
+solana-program-test = "1.14.0"
+solana-sdk = "1.14.0"
+solana-program ="1.14.0"
+solana-banks-client = "1.14.0"
+solana-program-runtime = "1.14.0"
+solana-client = "1.14.0"
+spl-token = "3.5.0"
+spl-associated-token-account = "1.1.2"
+anchor-lang = { version = "0.26.0", optional = true }
 async-trait = "0.1.52"
 futures = "0.3"
 borsh = "0.9"
@@ -28,4 +28,4 @@ chrono-humanize = "0.2"
 
 [dev-dependencies]
 program-for-tests = {path="tests/artifacts/program_for_tests"}
-solana-test-validator = "1.10"
+solana-test-validator = "1.14.0"

--- a/README.md
+++ b/README.md
@@ -6,12 +6,18 @@
 &nbsp;
 
 ## Setup
-This framework supports Solana v1.9 and Anchor v0.24.2 **OR** Solana v1.10 and Anchor v0.25.0. To use it in your project,
+This framework supports:
+    - Solana v1.9 and Anchor v0.24.2
+    - Solana v1.10 and Anchor v0.25.0
+    - Solana v1.14 and Anchor v0.26.0
+    
+To use it in your project,
 
 1. add one of the following in your `Cargo.toml`:
  
     - Solana ~1.9: `solana-test-framework = { git = "https://github.com/halbornlabs/solana-test-framework"}`
     - Solana ~1.10: `solana-test-framework = { git = "https://github.com/halbornlabs/solana-test-framework", branch = "solana1.10" }`
+    - Solana ~1.14: `solana-test-framework = { git = "https://github.com/halbornlabs/solana-test-framework", branch = "solana1.14" }`
 
 2. include `features = ["anchor"]` in your dependency declaration if you want to enable Anchor convenience methods
 

--- a/src/extensions/client/banks_client.rs
+++ b/src/extensions/client/banks_client.rs
@@ -142,6 +142,7 @@ impl ClientExtensions for BanksClient {
         account: &Pubkey,
         mint: &Pubkey,
         payer: &Keypair,
+        token_program_id: &Pubkey,
     ) -> Result<Pubkey, Box<dyn std::error::Error>> {
         let latest_blockhash = self.get_latest_blockhash().await?;
         let associated_token_account = get_associated_token_address(
@@ -152,6 +153,7 @@ impl ClientExtensions for BanksClient {
         &payer.pubkey(),
         &account,
         &mint,
+        &token_program_id
         );
 
         self.process_transaction(Transaction::new_signed_with_payer(

--- a/src/extensions/client/mod.rs
+++ b/src/extensions/client/mod.rs
@@ -106,6 +106,7 @@ pub trait ClientExtensions {
         _authority: &Pubkey,
         _mint: &Pubkey,
         _payer: &Keypair,
+        _token_program_id: &Pubkey,
     ) -> Result<Pubkey, Box<dyn std::error::Error>> {
         unimplemented!();
     }

--- a/src/extensions/client/rpc_client.rs
+++ b/src/extensions/client/rpc_client.rs
@@ -136,6 +136,7 @@ impl ClientExtensions for RpcClient {
         account: &Pubkey,
         mint: &Pubkey,
         payer: &Keypair,
+        token_program_id: &Pubkey,
     ) -> Result<Pubkey, Box<dyn std::error::Error>> {    
         let associated_token_account = get_associated_token_address(
             account,
@@ -148,6 +149,7 @@ impl ClientExtensions for RpcClient {
                     &payer.pubkey(),
                     &account,
                     &mint,
+                    &token_program_id,
                 )
             ],
             payer,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,12 +10,10 @@ macro_rules! processor {
     ($process_instruction:expr) => {
         Some(
             |first_instruction_account: usize,
-             input: &[u8],
-             invoke_context: &mut InvokeContext| {
-                builtin_process_instruction(
+             invoke_context: &mut solana_program_test::InvokeContext| {
+                $crate::builtin_process_instruction(
                     $process_instruction,
                     first_instruction_account,
-                    input,
                     invoke_context,
                 )
             },

--- a/tests/artifacts/program_for_tests/Cargo.toml
+++ b/tests/artifacts/program_for_tests/Cargo.toml
@@ -14,4 +14,4 @@ no-entrypoint = []
 cpi = ["no-entrypoint"]
 
 [dependencies]
-anchor-lang = { version = "0.25.0" }
+anchor-lang = { version = "0.26.0" }

--- a/tests/banks_client.rs
+++ b/tests/banks_client.rs
@@ -228,13 +228,14 @@ async fn create_associated_token_account() {
     let (mut program, _) = helpers::add_program();
     let payer = helpers::add_payer(&mut program);
     let mint_pubkey = Pubkey::new_unique();
+    let token_program_id = spl_token::ID; //could also use token-2022 ID
     //Create mint with defaults
     program.add_token_mint(mint_pubkey, None, 10, 0, None);
 
     let (mut banks_client, _payer_keypair, mut _recent_blockhash) = program.start().await;
 
     let token_account = banks_client
-        .create_associated_token_account(&payer.pubkey(), &mint_pubkey, &payer)
+        .create_associated_token_account(&payer.pubkey(), &mint_pubkey, &payer, &token_program_id)
         .await
         .unwrap();
 

--- a/tests/rpc_client.rs
+++ b/tests/rpc_client.rs
@@ -211,6 +211,7 @@ async fn create_associated_token_account() {
     let mut genesis_config = TestValidatorGenesis::default();
     let program_id = Pubkey::from_str("CwrqeMj2U8tFr1Rhkgwc84tpAsqbt9pTt2a4taoTADPr").unwrap();
     let program_path = "tests/artifacts/program_for_tests.so";
+    let token_program_id = spl_token::ID; //could also use token-2022 ID
 
     genesis_config.add_programs_with_path(
         &[
@@ -242,7 +243,7 @@ async fn create_associated_token_account() {
         .unwrap();
 
     let token_account = rpc_client
-        .create_associated_token_account(&payer.pubkey(), &mint.pubkey(), &payer)
+        .create_associated_token_account(&payer.pubkey(), &mint.pubkey(), &payer, &token_program_id)
         .await
         .unwrap();
 


### PR DESCRIPTION
This pull requests updates the solana dependencies to 1.14.0 and anchor to 0.26. Several functions were updated as-well as the processor macro.