### PR TITLE
Add Empty Account With Anchor

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,19 @@ pub fn add_account_with_anchor<T: AccountSerialize + AnchorSerialize + Discrimin
 )
 ```
 
+Add an empty [`Anchor`](https://docs.rs/anchor-lang/latest/anchor_lang/attr.account.html) account to the test environment with a specified data size. Note the total size of the accounts data is 8 (discriminator) + size.
+```rust
+#[cfg(feature = "anchor")]
+pub fn add_account_with_anchor<T: AccountSerialize + AnchorSerialize + Discriminator>(
+    &mut self,
+    pubkey: Pubkey,
+    owner: Pubkey,
+    size: u64,
+)
+
+local_env_builder.add_empty_account_with_anchor::<HelloCounter>(user_pubkey, program::id(), 32);
+
+```
 &nbsp;
 
 Add an account with the given balance to the test environment.

--- a/src/extensions/program_test.rs
+++ b/src/extensions/program_test.rs
@@ -50,6 +50,15 @@ pub trait ProgramTestExtension {
         executable: bool,
     );
 
+    #[cfg(feature = "anchor")]
+    /// Adds an empty anchor account with a discriminator and specified size.
+    fn add_empty_account_with_anchor<T: AnchorSerialize + Discriminator>(
+        &mut self,
+        pubkey: Pubkey,
+        owner: Pubkey,
+        size: usize,
+    );
+
     /// Adds an account with the given balance to the test environment.
     fn add_account_with_lamports(&mut self, pubkey: Pubkey, owner: Pubkey, lamports: u64);
 
@@ -165,6 +174,21 @@ impl ProgramTestExtension for ProgramTest {
         v.extend_from_slice(discriminator);
         v.extend_from_slice(&data);
         self.add_account_with_data(pubkey, owner, &v, executable);
+    }
+
+    #[cfg(feature = "anchor")]
+    fn add_empty_account_with_anchor<T: AnchorSerialize + Discriminator>(
+        &mut self,
+        pubkey: Pubkey,
+        owner: Pubkey,
+        size: usize,
+    ) {
+        let discriminator = &T::discriminator();
+        let data = vec![0_u8; size];
+        let mut v = Vec::new();
+        v.extend_from_slice(discriminator);
+        v.extend_from_slice(&data);
+        self.add_account_with_data(pubkey, owner, &v, false);
     }
 
     fn add_account_with_lamports(&mut self, pubkey: Pubkey, owner: Pubkey, lamports: u64) {

--- a/src/extensions/program_test.rs
+++ b/src/extensions/program_test.rs
@@ -176,6 +176,7 @@ impl ProgramTestExtension for ProgramTest {
         self.add_account_with_data(pubkey, owner, &v, executable);
     }
 
+    //Note that the total size is 8 (disciminator) + size
     #[cfg(feature = "anchor")]
     fn add_empty_account_with_anchor<T: AnchorSerialize + Discriminator>(
         &mut self,

--- a/tests/program_test.rs
+++ b/tests/program_test.rs
@@ -81,12 +81,11 @@ async fn add_empty_account_with_anchor() {
     let (mut program, program_id) = helpers::add_program();
 
     let acc_pubkey = Pubkey::new_unique();
-    let count = 0;
     program.add_empty_account_with_anchor::<CountTracker>(acc_pubkey, program_id, 50); //Size of the CountTracker struct is actually 8
     let (mut banks_client, _payer_keypair, mut _recent_blockhash) = program.start().await;
     let counter_acc = banks_client.get_account(acc_pubkey).await.unwrap().unwrap();
-    let anchor_acc_data = CountTracker::try_deserialize(&mut counter_acc.data.as_ref()).unwrap();
-    assert_eq!(count, anchor_acc_data.count);
+    CountTracker::try_deserialize(&mut counter_acc.data.as_ref()).unwrap(); //to ensure the data can be deserialized
+    assert_eq!(50 + 8, counter_acc.data.len()); //8 for discriminator and 50 for provided data size
 }
 
 #[tokio::test]


### PR DESCRIPTION
Add an account with an anchor discriminator and zeroed out data. This is useful in niche scenarios where you need to provide an anchor account with a specific size but can't initialize the account normally.